### PR TITLE
package: Removed Hive packages due to dependency conflicts

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/bazario/lib/user_features/welcome/splash_screen.dart
+++ b/bazario/lib/user_features/welcome/splash_screen.dart
@@ -6,6 +6,8 @@ import 'package:bazario/app/app_router.gr.dart';
 import 'package:bazario/utils/constants/image_strings.dart';
 import 'package:flutter/material.dart';
 
+import '../../utils/constants/colors.dart';
+
 @RoutePage()
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -89,7 +91,7 @@ class _SplashScreenState extends State<SplashScreen>
                       fontFamily: 'Khotam',
                       fontSize: 90,
                       fontWeight: FontWeight.bold,
-                      color: Colors.white,
+                      color: MyColors.kPrimaryColor,
                       shadows: [
                         Shadow(
                           blurRadius: _glowAnimation.value,

--- a/bazario/pubspec.lock
+++ b/bazario/pubspec.lock
@@ -605,22 +605,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.8"
-  hive:
-    dependency: "direct main"
-    description:
-      name: hive
-      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.3"
-  hive_flutter:
-    dependency: "direct main"
-    description:
-      name: hive_flutter
-      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   hotreloader:
     dependency: transitive
     description:
@@ -1107,7 +1091,7 @@ packages:
     source: hosted
     version: "1.2.1"
   source_gen:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: source_gen
       sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"

--- a/bazario/pubspec.yaml
+++ b/bazario/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   firebase_core: ^4.0.0
   cloud_firestore: ^6.0.0
   cupertino_icons: ^1.0.8
+  source_gen: ^3.1.0
   device_preview: ^1.2.0
   firebase_auth: ^6.0.1
   flutter:
@@ -44,18 +45,14 @@ dependencies:
   image_picker: ^1.2.0
   firebase_storage: ^13.0.0
   cached_network_image: ^3.4.1
-  hive: ^2.2.3
-  hive_flutter: ^1.1.0
 
 dev_dependencies:
-  auto_route_generator: ^7.3.2  # Uses source_gen ^1.0.0
-  build_runner: ^2.5.4
+  auto_route_generator: ^10.2.4  # <-- Change this line
+  build_runner: ^2.7.0 # You may also need to update build_runner
   lean_builder: ^0.1.0-alpha.13
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
-dependency_overrides:
-  source_gen: ^3.1.0
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 # The following section is specific to Flutter packages.


### PR DESCRIPTION
This PR removes the Hive packages (hive, hive_flutter, hive_generator) from the project. These packages were causing a dependency conflict with modern versions of source_gen, which is required by other packages like auto_route_generator